### PR TITLE
Update README for cross-platform instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,28 @@ This repository contains a simplified skeleton of the "Trainer+" Telegram bot ba
 
 ## Quick start
 
+### Unix/macOS
+
 ```bash
 python3 -m venv venv
 source venv/bin/activate
 pip install -r requirements.txt
 uvicorn trainer_bot.app.main:app --reload
+```
+
+### Windows
+
+```bash
+python -m venv venv
+venv\Scripts\activate
+pip install -r requirements.txt
+uvicorn trainer_bot.app.main:app --reload
+```
+
+### Docker (optional)
+
+```bash
+docker-compose up --build
 ```
 
 Open <http://localhost:8000/docs> for the Swagger UI.


### PR DESCRIPTION
## Summary
- add separate Unix/macOS and Windows setup instructions to the quick start
- document optional Docker usage

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e5f9077748329b3d8984f4b6a55a5