### PR TITLE
Add Telegram auth with token refresh

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ pydantic
 aiogram
 pytest
 httpx
+PyJWT

--- a/trainer_bot/app/api/auth.py
+++ b/trainer_bot/app/api/auth.py
@@ -1,0 +1,126 @@
+import hashlib
+import hmac
+import os
+from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
+from sqlalchemy.orm import Session
+
+from ..schemas.auth import TelegramAuth, TokenPair, RefreshRequest
+from ..services.db import get_session
+from ..models import User
+import jwt
+import datetime
+
+SECRET_KEY = os.getenv("SECRET_KEY", "secret")
+ALGORITHM = "HS256"
+ACCESS_EXPIRE_MIN = 30
+REFRESH_EXPIRE_DAYS = 7
+
+router = APIRouter(prefix="/auth", tags=["auth"])
+security = HTTPBearer()
+
+
+def create_access_token(user_id: int) -> str:
+    now = datetime.datetime.utcnow()
+    payload = {
+        "sub": str(user_id),
+        "type": "access",
+        "iat": now,
+        "exp": now + datetime.timedelta(minutes=ACCESS_EXPIRE_MIN),
+        "jti": os.urandom(8).hex(),
+    }
+    return jwt.encode(payload, SECRET_KEY, algorithm=ALGORITHM)
+
+
+def create_refresh_token(user_id: int) -> str:
+    now = datetime.datetime.utcnow()
+    payload = {
+        "sub": str(user_id),
+        "type": "refresh",
+        "iat": now,
+        "exp": now + datetime.timedelta(days=REFRESH_EXPIRE_DAYS),
+        "jti": os.urandom(8).hex(),
+    }
+    return jwt.encode(payload, SECRET_KEY, algorithm=ALGORITHM)
+
+
+def decode_token(token: str) -> dict:
+    return jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
+
+
+def verify_telegram(data: dict) -> bool:
+    token = os.getenv("BOT_TOKEN", "")
+    secret = hashlib.sha256(token.encode()).digest()
+    check_hash = data.pop("hash", "")
+    data_check = "\n".join(f"{k}={v}" for k, v in sorted(data.items()))
+    hmac_hash = hmac.new(secret, data_check.encode(), hashlib.sha256).hexdigest()
+    return hmac_hash == check_hash
+
+
+@router.post("/telegram", response_model=TokenPair)
+async def telegram_auth(auth: TelegramAuth):
+    data = auth.model_dump(exclude_none=True)
+    if not verify_telegram(data.copy()):
+        raise HTTPException(status_code=400, detail="invalid auth data")
+    with get_session() as session:
+        user = session.query(User).filter(User.telegram_id == auth.id).first()
+        if not user:
+            user = User(
+                telegram_id=auth.id,
+                first_name=auth.first_name,
+                last_name=auth.last_name,
+                username=auth.username,
+            )
+            session.add(user)
+            session.commit()
+            session.refresh(user)
+        access = create_access_token(user.id)
+        refresh = create_refresh_token(user.id)
+        user.refresh_token = refresh
+        session.commit()
+        return TokenPair(access_token=access, refresh_token=refresh)
+
+
+@router.post("/refresh", response_model=TokenPair)
+async def refresh_token(data: RefreshRequest):
+    try:
+        payload = decode_token(data.refresh_token)
+    except Exception:
+        raise HTTPException(status_code=401, detail="invalid token")
+    if payload.get("type") != "refresh":
+        raise HTTPException(status_code=400, detail="invalid token type")
+    user_id = payload.get("sub")
+    with get_session() as session:
+        user = session.get(User, user_id)
+        if not user or user.refresh_token != data.refresh_token:
+            raise HTTPException(status_code=401, detail="invalid token")
+        access = create_access_token(user.id)
+        refresh = create_refresh_token(user.id)
+        user.refresh_token = refresh
+        session.commit()
+        return TokenPair(access_token=access, refresh_token=refresh)
+
+
+def get_current_user(credentials: HTTPAuthorizationCredentials = Depends(security)) -> User:
+    token = credentials.credentials
+    try:
+        payload = decode_token(token)
+    except Exception:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="invalid token")
+    if payload.get("type") != "access":
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="invalid token type")
+    user_id = payload.get("sub")
+    with get_session() as session:
+        user = session.get(User, user_id)
+        if not user:
+            raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="user not found")
+        return user
+
+
+def require_roles(roles: list[str]):
+    def dependency(user: User = Depends(get_current_user)):
+        if user.role not in roles:
+            raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="forbidden")
+        return user
+
+    return dependency

--- a/trainer_bot/app/api/protected.py
+++ b/trainer_bot/app/api/protected.py
@@ -1,0 +1,8 @@
+from fastapi import APIRouter, Depends
+from .auth import require_roles
+
+router = APIRouter(prefix="/protected", tags=["protected"])
+
+@router.get("/ping")
+async def protected_ping(user=Depends(require_roles(["user"]))):
+    return {"status": "ok", "user_id": user.id}

--- a/trainer_bot/app/main.py
+++ b/trainer_bot/app/main.py
@@ -1,6 +1,6 @@
 from fastapi import FastAPI
 
-from .api import athletes, workouts, sets, plans, reports, notifications, messages, telegram
+from .api import athletes, workouts, sets, plans, reports, notifications, messages, telegram, auth, protected
 
 app = FastAPI(title="Trainer Bot API")
 
@@ -12,6 +12,8 @@ app.include_router(reports.router, prefix="/api/v1")
 app.include_router(notifications.router, prefix="/api/v1")
 app.include_router(messages.router, prefix="/api/v1")
 app.include_router(telegram.router)
+app.include_router(auth.router, prefix="/api/v1")
+app.include_router(protected.router, prefix="/api/v1")
 
 @app.get("/ping")
 async def ping():

--- a/trainer_bot/app/models.py
+++ b/trainer_bot/app/models.py
@@ -54,3 +54,13 @@ class Notification(Base):
     user_id = Column(Integer, nullable=False)
     text = Column(Text, nullable=False)
     created_at = Column(DateTime, default=datetime.datetime.utcnow)
+
+class User(Base):
+    __tablename__ = 'users'
+    id = Column(Integer, primary_key=True)
+    telegram_id = Column(Integer, unique=True, nullable=False)
+    first_name = Column(String)
+    last_name = Column(String)
+    username = Column(String)
+    role = Column(String, default='user', nullable=False)
+    refresh_token = Column(String, nullable=True)

--- a/trainer_bot/app/schemas/auth.py
+++ b/trainer_bot/app/schemas/auth.py
@@ -1,0 +1,17 @@
+from pydantic import BaseModel
+
+class TelegramAuth(BaseModel):
+    id: int
+    first_name: str | None = None
+    last_name: str | None = None
+    username: str | None = None
+    auth_date: int
+    hash: str
+
+class TokenPair(BaseModel):
+    access_token: str
+    refresh_token: str
+    token_type: str = "bearer"
+
+class RefreshRequest(BaseModel):
+    refresh_token: str

--- a/trainer_bot/tests/integration/test_auth.py
+++ b/trainer_bot/tests/integration/test_auth.py
@@ -1,0 +1,37 @@
+import os
+import hashlib
+import hmac
+from trainer_bot.app.main import app
+from fastapi.testclient import TestClient
+
+client = TestClient(app)
+
+BOT_TOKEN = "testtoken"
+os.environ["BOT_TOKEN"] = BOT_TOKEN
+
+
+def _telegram_payload(user_id: int = 1):
+    data = {
+        "id": user_id,
+        "first_name": "Test",
+        "auth_date": 1,
+    }
+    secret = hashlib.sha256(BOT_TOKEN.encode()).digest()
+    data_check = "\n".join(f"{k}={v}" for k, v in sorted(data.items()))
+    data["hash"] = hmac.new(secret, data_check.encode(), hashlib.sha256).hexdigest()
+    return data
+
+
+def test_telegram_auth_and_refresh():
+    payload = _telegram_payload()
+    res = client.post("/api/v1/auth/telegram", json=payload)
+    assert res.status_code == 200
+    tokens = res.json()
+    assert "access_token" in tokens
+    assert "refresh_token" in tokens
+
+    res2 = client.post("/api/v1/auth/refresh", json={"refresh_token": tokens["refresh_token"]})
+    assert res2.status_code == 200
+    new_tokens = res2.json()
+    assert new_tokens["refresh_token"] != tokens["refresh_token"]
+    assert "access_token" in new_tokens


### PR DESCRIPTION
## Summary
- add JWT-based Telegram auth and refresh endpoints
- add user roles table
- require roles via dependency for protected endpoints
- test access/refresh token issuance

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e7da592b483299f912d300c6334d4