### PR TITLE
Implement reminders and inline set updates

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ pydantic
 aiogram
 pytest
 httpx
+APScheduler

--- a/run_bot.py
+++ b/run_bot.py
@@ -1,7 +1,9 @@
 import asyncio
 from trainer_bot.app.bots.telegram.dispatcher import bot, dp
+from trainer_bot.app.services.scheduler import setup_scheduler
 
 async def main():
+    setup_scheduler()
     await dp.start_polling(bot)
 
 if __name__ == '__main__':

--- a/trainer_bot/app/bots/telegram/dispatcher.py
+++ b/trainer_bot/app/bots/telegram/dispatcher.py
@@ -1,9 +1,10 @@
 from aiogram import Bot, Dispatcher
-from aiogram.types import Message
+from aiogram.types import Message, CallbackQuery, InlineKeyboardMarkup, InlineKeyboardButton
 from aiogram.filters import CommandStart, Command
 from datetime import date
 from ...services.db import get_session
-from ...models import Workout
+from ...models import Workout, Set
+import httpx
 import os
 
 API_TOKEN = os.getenv("BOT_TOKEN", "123456:ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghi")
@@ -17,7 +18,7 @@ async def start(message: Message):
 
 @dp.message(Command("help"))
 async def help_cmd(message: Message):
-    await message.answer("Available commands: /start /help /today")
+    await message.answer("Available commands: /start /help /today /future /proxy")
 
 @dp.message(Command("today"))
 async def today_cmd(message: Message):
@@ -25,7 +26,60 @@ async def today_cmd(message: Message):
     with get_session() as session:
         todays = session.query(Workout).filter(Workout.date == today).all()
     if todays:
-        text = "Today's workouts:\n" + "\n".join(w.title for w in todays)
+        for w in todays:
+            await message.answer(f"{w.title}")
+            sets = session.query(Set).filter(Set.workout_id == w.id).all()
+            for s in sets:
+                kb = InlineKeyboardMarkup(inline_keyboard=[[
+                    InlineKeyboardButton(text="20kg×5", callback_data=f"set:{s.id}:20:5"),
+                    InlineKeyboardButton(text="25kg×5", callback_data=f"set:{s.id}:25:5")
+                ]])
+                await message.answer(f"{s.exercise} {s.weight}×{s.reps}", reply_markup=kb)
     else:
-        text = "No workouts for today."
+        await message.answer("No workouts for today.")
+
+@dp.message(Command("proxy"))
+async def proxy_cmd(message: Message):
+    parts = message.text.split(maxsplit=1)
+    if len(parts) < 2:
+        await message.answer("Usage: /proxy <text>")
+        return
+    text = parts[1]
+    trainer_chat = os.getenv("TRAINER_CHAT_ID")
+    athlete_chat = os.getenv("ATHLETE_CHAT_ID")
+    dest = athlete_chat if str(message.chat.id) == trainer_chat else trainer_chat
+    if dest:
+        await bot.send_message(dest, text)
+
+@dp.message(Command("future"))
+async def future_cmd(message: Message):
+    today = date.today()
+    with get_session() as session:
+        items = session.query(Workout).filter(Workout.date >= today).all()
+    if not items:
+        await message.answer("No future workouts")
+        return
+    text = "Upcoming workouts:\n" + "\n".join(f"{w.date} {w.title}" for w in items)
     await message.answer(text)
+
+@dp.callback_query(lambda c: c.data.startswith("set:"))
+async def set_callback(call: CallbackQuery):
+    _, set_id, weight, reps = call.data.split(":")
+    set_id = int(set_id)
+    async with httpx.AsyncClient() as client:
+        with get_session() as session:
+            obj = session.get(Set, set_id)
+        if not obj:
+            await call.answer("Set not found")
+            return
+        payload = {
+            "workout_id": obj.workout_id,
+            "exercise": obj.exercise,
+            "weight": float(weight),
+            "reps": int(reps),
+            "order": obj.order,
+        }
+        url = f"http://localhost:8000/api/v1/sets/{set_id}"
+        await client.patch(url, json=payload)
+    await call.answer("Updated")
+

--- a/trainer_bot/app/services/scheduler.py
+++ b/trainer_bot/app/services/scheduler.py
@@ -1,0 +1,54 @@
+from apscheduler.schedulers.asyncio import AsyncIOScheduler
+from datetime import datetime, timedelta
+from zoneinfo import ZoneInfo
+import os
+
+from ..models import Workout
+from .db import get_session
+from ..bots.telegram.dispatcher import bot
+
+scheduler = AsyncIOScheduler()
+
+async def _send(chat_id: str, text: str):
+    await bot.send_message(chat_id, text)
+
+async def workout_reminder(workout_id: int):
+    with get_session() as session:
+        w = session.get(Workout, workout_id)
+    if not w:
+        return
+    text = f"Reminder: workout '{w.title}' in one hour"
+    trainer_chat = os.getenv("TRAINER_CHAT_ID")
+    athlete_chat = os.getenv("ATHLETE_CHAT_ID")
+    if trainer_chat:
+        await _send(trainer_chat, text)
+    if athlete_chat:
+        await _send(athlete_chat, text)
+
+async def daily_reminder():
+    tz = ZoneInfo(os.getenv("TZ", "UTC"))
+    tomorrow = datetime.now(tz).date() + timedelta(days=1)
+    with get_session() as session:
+        workouts = session.query(Workout).filter(Workout.date == tomorrow).all()
+    if not workouts:
+        return
+    text = "Tomorrow's workouts:\n" + "\n".join(w.title for w in workouts)
+    trainer_chat = os.getenv("TRAINER_CHAT_ID")
+    athlete_chat = os.getenv("ATHLETE_CHAT_ID")
+    if trainer_chat:
+        await _send(trainer_chat, text)
+    if athlete_chat:
+        await _send(athlete_chat, text)
+
+
+def setup_scheduler():
+    tz = ZoneInfo(os.getenv("TZ", "UTC"))
+    scheduler.configure(timezone=tz)
+    scheduler.add_job(daily_reminder, 'cron', hour=20, minute=0)
+    with get_session() as session:
+        workouts = session.query(Workout).all()
+        for w in workouts:
+            dt = datetime.combine(w.date, datetime.min.time(), tzinfo=tz) - timedelta(hours=1)
+            scheduler.add_job(workout_reminder, 'date', run_date=dt, args=[w.id])
+    scheduler.start()
+


### PR DESCRIPTION
## Summary
- support inline button callbacks to PATCH `/sets/{id}` via Telegram
- implement `/future` and `/proxy` commands
- add async scheduler for workout reminders
- start scheduler when running bot
- include APScheduler in requirements

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e808aeba48329b49b68b6caff675a