### PR TITLE
Add redis & postgres, CI improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,4 +9,21 @@ jobs:
         with:
           python-version: '3.12'
       - run: pip install -r requirements.txt
-      - run: PYTHONPATH=. pytest -q
+      - name: Lint
+        run: ruff .
+      - name: Test
+        run: PYTHONPATH=. pytest --cov=trainer_bot --cov-report=xml --cov-report=term --cov-fail-under=70
+      - uses: actions/upload-artifact@v3
+        with:
+          name: coverage-report
+          path: coverage.xml
+      - uses: docker/setup-qemu-action@v2
+      - uses: docker/setup-buildx-action@v2
+      - uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - uses: docker/build-push-action@v5
+        with:
+          push: true
+          tags: ${{ secrets.DOCKER_USERNAME }}/trainer-bot-backend:latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,31 @@
 version: '3.8'
 services:
+  db:
+    image: postgres:16
+    environment:
+      POSTGRES_USER: trainer
+      POSTGRES_PASSWORD: trainer
+      POSTGRES_DB: trainer
+    volumes:
+      - db-data:/var/lib/postgresql/data
+    ports:
+      - "5432:5432"
+
+  redis:
+    image: redis:7
+    ports:
+      - "6379:6379"
+
   app:
     build: .
+    environment:
+      DATABASE_URL: postgres://trainer:trainer@db:5432/trainer
+      REDIS_URL: redis://redis:6379/0
+    depends_on:
+      - db
+      - redis
     ports:
       - "8000:8000"
+
+volumes:
+  db-data:

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,5 @@ aiogram
 pytest
 httpx
 PyJWT
+pytest-cov
+ruff

--- a/trainer_bot/app/api/auth.py
+++ b/trainer_bot/app/api/auth.py
@@ -3,7 +3,6 @@ import hmac
 import os
 from fastapi import APIRouter, Depends, HTTPException, status
 from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
-from sqlalchemy.orm import Session
 
 from ..schemas.auth import TelegramAuth, TokenPair, RefreshRequest
 from ..services.db import get_session

--- a/trainer_bot/app/api/messages.py
+++ b/trainer_bot/app/api/messages.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter
 from typing import List
 from ..schemas.message import MessageCreate, Message as MessageSchema
 from ..services.db import get_session

--- a/trainer_bot/app/api/reports.py
+++ b/trainer_bot/app/api/reports.py
@@ -1,5 +1,4 @@
 from fastapi import APIRouter
-from typing import List
 from ..services.db import get_session
 from ..models import Workout
 

--- a/trainer_bot/app/services/db.py
+++ b/trainer_bot/app/services/db.py
@@ -10,7 +10,7 @@ SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 Base = declarative_base()
 
 # Import models so that metadata is populated before creating tables
-from .. import models  # noqa: E402
+from .. import models  # noqa: F401,E402
 
 Base.metadata.create_all(bind=engine)
 

--- a/trainer_bot/migrations/env.py
+++ b/trainer_bot/migrations/env.py
@@ -1,5 +1,4 @@
 from logging.config import fileConfig
-from sqlalchemy import engine_from_config, pool
 from alembic import context
 import os
 

--- a/trainer_bot/tests/integration/test_protected.py
+++ b/trainer_bot/tests/integration/test_protected.py
@@ -1,0 +1,39 @@
+import os
+import hashlib
+import hmac
+from trainer_bot.app.main import app
+from fastapi.testclient import TestClient
+
+client = TestClient(app)
+BOT_TOKEN = "testtoken"
+os.environ["BOT_TOKEN"] = BOT_TOKEN
+
+
+def _telegram_payload(user_id: int = 1):
+    data = {
+        "id": user_id,
+        "first_name": "Test",
+        "auth_date": 1,
+    }
+    secret = hashlib.sha256(BOT_TOKEN.encode()).digest()
+    data_check = "\n".join(f"{k}={v}" for k, v in sorted(data.items()))
+    data["hash"] = hmac.new(secret, data_check.encode(), hashlib.sha256).hexdigest()
+    return data
+
+
+def _auth_headers():
+    res = client.post("/api/v1/auth/telegram", json=_telegram_payload())
+    token = res.json()["access_token"]
+    return {"Authorization": f"Bearer {token}"}
+
+
+def test_protected_requires_auth():
+    res = client.get("/api/v1/protected/ping")
+    assert res.status_code == 403
+
+
+def test_protected_ping():
+    headers = _auth_headers()
+    res = client.get("/api/v1/protected/ping", headers=headers)
+    assert res.status_code == 200
+    assert res.json() == {"status": "ok", "user_id": 1}


### PR DESCRIPTION
## Summary
- extend compose stack with Postgres and Redis
- lint, tests, build and push Docker image in CI
- add pytest-cov and ruff
- new tests for protected endpoint
- fix ruff issues

## Testing
- `ruff check .`
- `pytest -q --cov=trainer_bot --cov-report=xml --cov-report=term --cov-fail-under=70`


------
https://chatgpt.com/codex/tasks/task_e_686e84f1a4608329bea7cd498e7bcec0