### PR TITLE
Add Telegram API command

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,3 +63,20 @@ python run_bot.py
 
 After starting the script the bot will begin polling Telegram and will
 reply with `Hello! This is Trainer Bot` when you send the `/start` command.
+
+### Using API commands via Telegram
+
+The bot exposes an `/api` command so the trainer can call any backend endpoint
+directly from Telegram. Usage:
+
+```text
+/api <method> <path> [json]
+```
+
+Example:
+
+```text
+/api get /api/v1/workouts
+```
+
+To authenticate requests, set `TRAINER_API_TOKEN` with a valid bearer token.


### PR DESCRIPTION
## Summary
- let trainers invoke API endpoints with `/api`
- document new capability in README

## Testing
- `ruff check .`
- `pytest --cov=trainer_bot --cov-report=term --cov-report=xml`

------
https://chatgpt.com/codex/tasks/task_e_686e917063708329b37e054487329568