### PR TITLE
Add Telegram workflow for creating athletes and workouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,9 @@ reply with `Hello! This is Trainer Bot` when you send the `/start` command.
 The `/start` or `/menu` command displays quick action buttons so a trainer can
 navigate the bot without typing raw API requests.
 
+The bot now supports interactive creation of athletes and workouts. Use
+`/add_athlete` or `/add_workout` from Telegram and follow the prompts.
+
 ### Using API commands via Telegram
 
 The bot exposes an `/api` command so the trainer can call any backend endpoint


### PR DESCRIPTION
## Summary
- extend Telegram bot menu and help with add athlete/workout options
- implement conversation flow to create athletes and workouts via Telegram
- document the new Telegram commands in README

## Testing
- `ruff check`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f6c452e6c8329b9fdaf57299c073f