### PR TITLE
Improve Telegram bot auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,9 @@ Example:
 /api get /api/v1/workouts
 ```
 
-To authenticate requests, set `TRAINER_API_TOKEN` with a valid bearer token.
+By default the bot obtains an access token automatically using your Telegram
+account through the `/api/v1/auth/bot` endpoint. You can override the token by
+setting `TRAINER_API_TOKEN` with a valid bearer token.
 
 ### Time zone
 

--- a/trainer_bot/app/api/auth.py
+++ b/trainer_bot/app/api/auth.py
@@ -4,7 +4,7 @@ import os
 from fastapi import APIRouter, Depends, HTTPException, status
 from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
 
-from ..schemas.auth import TelegramAuth, TokenPair, RefreshRequest
+from ..schemas.auth import TelegramAuth, TokenPair, RefreshRequest, BotAuth
 from ..services.db import get_session
 from ..models import User
 import jwt
@@ -69,6 +69,30 @@ async def telegram_auth(auth: TelegramAuth):
                 first_name=auth.first_name,
                 last_name=auth.last_name,
                 username=auth.username,
+            )
+            session.add(user)
+            session.commit()
+            session.refresh(user)
+        access = create_access_token(user.id)
+        refresh = create_refresh_token(user.id)
+        user.refresh_token = refresh
+        session.commit()
+        return TokenPair(access_token=access, refresh_token=refresh)
+
+
+@router.post("/bot", response_model=TokenPair)
+async def bot_auth(data: BotAuth):
+    bot_token = os.getenv("BOT_TOKEN", "")
+    if data.bot_token != bot_token:
+        raise HTTPException(status_code=401, detail="invalid bot token")
+    with get_session() as session:
+        user = session.query(User).filter(User.telegram_id == data.telegram_id).first()
+        if not user:
+            user = User(
+                telegram_id=data.telegram_id,
+                first_name=data.first_name,
+                last_name=data.last_name,
+                username=data.username,
             )
             session.add(user)
             session.commit()

--- a/trainer_bot/app/schemas/auth.py
+++ b/trainer_bot/app/schemas/auth.py
@@ -15,3 +15,11 @@ class TokenPair(BaseModel):
 
 class RefreshRequest(BaseModel):
     refresh_token: str
+
+
+class BotAuth(BaseModel):
+    telegram_id: int
+    first_name: str | None = None
+    last_name: str | None = None
+    username: str | None = None
+    bot_token: str

--- a/trainer_bot/tests/integration/test_auth.py
+++ b/trainer_bot/tests/integration/test_auth.py
@@ -22,6 +22,14 @@ def _telegram_payload(user_id: int = 1):
     return data
 
 
+def _bot_payload(user_id: int = 2):
+    return {
+        "telegram_id": user_id,
+        "first_name": "Test",
+        "bot_token": BOT_TOKEN,
+    }
+
+
 def test_telegram_auth_and_refresh():
     payload = _telegram_payload()
     res = client.post("/api/v1/auth/telegram", json=payload)
@@ -35,3 +43,11 @@ def test_telegram_auth_and_refresh():
     new_tokens = res2.json()
     assert new_tokens["refresh_token"] != tokens["refresh_token"]
     assert "access_token" in new_tokens
+
+
+def test_bot_auth():
+    res = client.post("/api/v1/auth/bot", json=_bot_payload())
+    assert res.status_code == 200
+    data = res.json()
+    assert "access_token" in data
+    assert "refresh_token" in data


### PR DESCRIPTION
## Summary
- support new `BotAuth` API for seamless Telegram login
- have the bot request tokens automatically
- document automatic token retrieval
- test the new auth flow

## Testing
- `pip install -r requirements.txt`
- `pytest -q`
- `ruff check .`

------
https://chatgpt.com/codex/tasks/task_e_686f890dcf5c832991ece2c9acfa4e01