### PR TITLE
Add workout time field and bot update

### DIFF
--- a/trainer_bot/app/bots/telegram/dispatcher.py
+++ b/trainer_bot/app/bots/telegram/dispatcher.py
@@ -243,6 +243,10 @@ async def handle_flow(message: Message):
             await message.answer("Введите дату тренировки (ГГГГ-ММ-ДД):")
         elif state["step"] == "date":
             state["date"] = message.text.strip()
+            state["step"] = "time"
+            await message.answer("Введите время тренировки (ЧЧ:ММ):")
+        elif state["step"] == "time":
+            state["time"] = message.text.strip()
             state["step"] = "type"
             await message.answer("Введите тип тренировки (например, силовая):")
         elif state["step"] == "type":
@@ -254,6 +258,7 @@ async def handle_flow(message: Message):
             payload = {
                 "athlete_id": int(state["athlete_id"]),
                 "date": state["date"],
+                "time": state.get("time"),
                 "type": state["type"],
                 "title": state["title"],
             }

--- a/trainer_bot/app/models.py
+++ b/trainer_bot/app/models.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, Integer, String, Date, Text, Float, ForeignKey, DateTime
+from sqlalchemy import Column, Integer, String, Date, Time, Text, Float, ForeignKey, DateTime
 from sqlalchemy.orm import relationship
 import datetime
 
@@ -24,6 +24,7 @@ class Workout(Base):
     id = Column(Integer, primary_key=True)
     athlete_id = Column(Integer, ForeignKey('athletes.id'), nullable=False)
     date = Column(Date, nullable=False)
+    time = Column(Time)
     type = Column(String, nullable=False)
     title = Column(String, nullable=False)
     notes = Column(Text)

--- a/trainer_bot/app/schemas/workout.py
+++ b/trainer_bot/app/schemas/workout.py
@@ -1,9 +1,11 @@
 from pydantic import BaseModel
-from datetime import date
+from datetime import date, time as time_
+from typing import Optional
 
 class WorkoutBase(BaseModel):
     athlete_id: int
     date: date
+    time: Optional[time_] = None
     type: str
     title: str
     notes: str | None = None

--- a/trainer_bot/app/services/scheduler.py
+++ b/trainer_bot/app/services/scheduler.py
@@ -48,7 +48,8 @@ def setup_scheduler():
     with get_session() as session:
         workouts = session.query(Workout).all()
         for w in workouts:
-            dt = tz.localize(datetime.combine(w.date, datetime.min.time())) - timedelta(hours=1)
+            w_dt = datetime.combine(w.date, w.time or datetime.min.time())
+            dt = tz.localize(w_dt) - timedelta(hours=1)
             scheduler.add_job(workout_reminder, 'date', run_date=dt, args=[w.id])
     scheduler.start()
 

--- a/trainer_bot/migrations/versions/0004_add_workout_time.py
+++ b/trainer_bot/migrations/versions/0004_add_workout_time.py
@@ -1,0 +1,15 @@
+from alembic import op
+import sqlalchemy as sa
+
+revision = '0004_add_workout_time'
+down_revision = '0003_add_contraindications'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('workouts', sa.Column('time', sa.Time(), nullable=True))
+
+
+def downgrade():
+    op.drop_column('workouts', 'time')

--- a/trainer_bot/tests/integration/test_workouts_time.py
+++ b/trainer_bot/tests/integration/test_workouts_time.py
@@ -1,0 +1,38 @@
+import os
+import hashlib
+import hmac
+from trainer_bot.app.main import app
+from fastapi.testclient import TestClient
+
+client = TestClient(app)
+BOT_TOKEN = "testtoken"
+os.environ["BOT_TOKEN"] = BOT_TOKEN
+
+
+def _telegram_payload(user_id: int = 1, role: str | None = None):
+    data = {
+        "id": user_id,
+        "first_name": "Test",
+        "auth_date": 1,
+    }
+    secret = hashlib.sha256(BOT_TOKEN.encode()).digest()
+    data_check = "\n".join(f"{k}={v}" for k, v in sorted(data.items()))
+    data["hash"] = hmac.new(secret, data_check.encode(), hashlib.sha256).hexdigest()
+    if role:
+        data["role"] = role
+    return data
+
+
+def _auth_headers():
+    res = client.post("/api/v1/auth/telegram", json=_telegram_payload(role="coach"))
+    token = res.json()["access_token"]
+    return {"Authorization": f"Bearer {token}"}
+
+
+def test_create_workout_with_time():
+    headers = _auth_headers()
+    payload = {"athlete_id": 1, "date": "2025-01-02", "time": "10:30", "type": "strength", "title": "W"}
+    res = client.post("/api/v1/workouts/", json=payload, headers=headers)
+    assert res.status_code == 200
+    data = res.json()
+    assert data["time"] == "10:30:00"


### PR DESCRIPTION
## Summary
- enable storing time for a workout
- add Alembic migration for workout time
- update pydantic schema and scheduler
- extend `/add_workout` bot flow to request time
- test creating a workout with time

## Testing
- `ruff check trainer_bot`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686faf05211c8329b5e548c8b146e108