### PR TITLE
Add invite tokens

### DIFF
--- a/trainer_bot/app/api/invites.py
+++ b/trainer_bot/app/api/invites.py
@@ -1,0 +1,111 @@
+import os
+import datetime
+import jwt
+from fastapi import APIRouter, Depends, HTTPException
+
+from ..schemas.invite import InviteCreate, InviteUseTelegram, InviteUseBot
+from ..schemas.auth import TokenPair
+from ..services.db import get_session
+from ..models import Invite, Role, User
+from .auth import require_roles, verify_telegram, create_access_token, create_refresh_token, SECRET_KEY, ALGORITHM
+
+router = APIRouter(prefix="/invites", tags=["invites"])
+
+
+def _create_invite_token(role: str, issuer_id: int) -> str:
+    now = datetime.datetime.utcnow()
+    jti = os.urandom(8).hex()
+    payload = {
+        "jti": jti,
+        "type": "invite",
+        "role": role,
+        "iss": str(issuer_id),
+        "iat": now,
+    }
+    token = jwt.encode(payload, SECRET_KEY, algorithm=ALGORITHM)
+    with get_session() as session:
+        session.add(Invite(jti=jti, role=role, issued_by=issuer_id))
+        session.commit()
+    return token
+
+
+@router.post("/", response_model=dict)
+async def issue_invite(data: InviteCreate, user=Depends(require_roles([Role.coach, Role.superadmin]))):
+    role = data.role.value if data.role else Role.athlete.value
+    token = _create_invite_token(role, user.id)
+    return {"invite_token": token}
+
+
+@router.post("/telegram", response_model=TokenPair)
+async def telegram_signup(auth: InviteUseTelegram):
+    verify_data = auth.model_dump().copy()
+    verify_data.pop("invite_token")
+    if not verify_telegram(verify_data):
+        raise HTTPException(status_code=400, detail="invalid auth data")
+    try:
+        payload = jwt.decode(auth.invite_token, SECRET_KEY, algorithms=[ALGORITHM])
+    except Exception:
+        raise HTTPException(status_code=400, detail="invalid invite token")
+    if payload.get("type") != "invite":
+        raise HTTPException(status_code=400, detail="invalid invite token")
+    jti = payload.get("jti")
+    with get_session() as session:
+        invite = session.query(Invite).filter(Invite.jti == jti, Invite.used.is_(False)).first()
+        if not invite:
+            raise HTTPException(status_code=400, detail="invite not found or used")
+        user = session.query(User).filter(User.telegram_id == auth.id).first()
+        if not user:
+            user = User(
+                telegram_id=auth.id,
+                first_name=auth.first_name,
+                last_name=auth.last_name,
+                username=auth.username,
+                role=invite.role,
+            )
+            session.add(user)
+            session.commit()
+            session.refresh(user)
+        invite.used = True
+        session.commit()
+        access = create_access_token(user.id)
+        refresh = create_refresh_token(user.id)
+        user.refresh_token = refresh
+        session.commit()
+        return TokenPair(access_token=access, refresh_token=refresh)
+
+
+@router.post("/bot", response_model=TokenPair)
+async def bot_signup(data: InviteUseBot):
+    bot_token = os.getenv("BOT_TOKEN", "")
+    if data.bot_token != bot_token:
+        raise HTTPException(status_code=401, detail="invalid bot token")
+    try:
+        payload = jwt.decode(data.invite_token, SECRET_KEY, algorithms=[ALGORITHM])
+    except Exception:
+        raise HTTPException(status_code=400, detail="invalid invite token")
+    if payload.get("type") != "invite":
+        raise HTTPException(status_code=400, detail="invalid invite token")
+    jti = payload.get("jti")
+    with get_session() as session:
+        invite = session.query(Invite).filter(Invite.jti == jti, Invite.used.is_(False)).first()
+        if not invite:
+            raise HTTPException(status_code=400, detail="invite not found or used")
+        user = session.query(User).filter(User.telegram_id == data.telegram_id).first()
+        if not user:
+            user = User(
+                telegram_id=data.telegram_id,
+                first_name=data.first_name,
+                last_name=data.last_name,
+                username=data.username,
+                role=invite.role,
+            )
+            session.add(user)
+            session.commit()
+            session.refresh(user)
+        invite.used = True
+        session.commit()
+        access = create_access_token(user.id)
+        refresh = create_refresh_token(user.id)
+        user.refresh_token = refresh
+        session.commit()
+        return TokenPair(access_token=access, refresh_token=refresh)

--- a/trainer_bot/app/main.py
+++ b/trainer_bot/app/main.py
@@ -1,6 +1,6 @@
 from fastapi import FastAPI
 
-from .api import athletes, workouts, sets, plans, reports, notifications, messages, telegram, auth, protected, exercises
+from .api import athletes, workouts, sets, plans, reports, notifications, messages, telegram, auth, protected, exercises, invites
 
 app = FastAPI(title="Trainer Bot API")
 
@@ -14,6 +14,7 @@ app.include_router(notifications.router, prefix="/api/v1")
 app.include_router(messages.router, prefix="/api/v1")
 app.include_router(telegram.router)
 app.include_router(auth.router, prefix="/api/v1")
+app.include_router(invites.router, prefix="/api/v1")
 app.include_router(protected.router, prefix="/api/v1")
 
 @app.get("/ping")

--- a/trainer_bot/app/models.py
+++ b/trainer_bot/app/models.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, Integer, String, Date, Time, Text, Float, ForeignKey, DateTime
+from sqlalchemy import Column, Integer, String, Date, Time, Text, Float, ForeignKey, DateTime, Boolean
 from sqlalchemy.orm import relationship
 import datetime
 
@@ -91,3 +91,13 @@ class User(Base):
     username = Column(String)
     role = Column(String, default=Role.athlete.value, nullable=False)
     refresh_token = Column(String, nullable=True)
+
+
+class Invite(Base):
+    __tablename__ = 'invites'
+    id = Column(Integer, primary_key=True)
+    jti = Column(String, unique=True, nullable=False)
+    role = Column(String, default=Role.athlete.value, nullable=False)
+    issued_by = Column(Integer, ForeignKey('users.id'), nullable=False)
+    used = Column(Boolean, default=False, nullable=False)
+    issued_at = Column(DateTime, default=datetime.datetime.utcnow)

--- a/trainer_bot/app/schemas/auth.py
+++ b/trainer_bot/app/schemas/auth.py
@@ -9,6 +9,7 @@ class TelegramAuth(BaseModel):
     auth_date: int
     hash: str
     role: Role | None = None
+    invite_token: str | None = None
 
 class TokenPair(BaseModel):
     access_token: str
@@ -26,6 +27,7 @@ class BotAuth(BaseModel):
     username: str | None = None
     bot_token: str
     role: Role | None = None
+    invite_token: str | None = None
 
 class RoleUpdate(BaseModel):
     role: Role

--- a/trainer_bot/app/schemas/invite.py
+++ b/trainer_bot/app/schemas/invite.py
@@ -1,0 +1,25 @@
+from pydantic import BaseModel
+from ..models import Role
+
+
+class InviteCreate(BaseModel):
+    role: Role | None = None
+
+
+class InviteUseTelegram(BaseModel):
+    invite_token: str
+    id: int
+    first_name: str | None = None
+    last_name: str | None = None
+    username: str | None = None
+    auth_date: int
+    hash: str
+
+
+class InviteUseBot(BaseModel):
+    invite_token: str
+    telegram_id: int
+    first_name: str | None = None
+    last_name: str | None = None
+    username: str | None = None
+    bot_token: str

--- a/trainer_bot/tests/integration/test_invites.py
+++ b/trainer_bot/tests/integration/test_invites.py
@@ -1,0 +1,48 @@
+import os
+os.environ["BOT_TOKEN"] = "123456:TESTTOKEN"
+
+import hashlib
+import hmac
+from trainer_bot.app.main import app
+from fastapi.testclient import TestClient
+
+client = TestClient(app)
+BOT_TOKEN = "123456:TESTTOKEN"
+
+
+def _telegram_payload(user_id: int = 1):
+    data = {
+        "id": user_id,
+        "first_name": "Test",
+        "auth_date": 1,
+    }
+    secret = hashlib.sha256(BOT_TOKEN.encode()).digest()
+    data_check = "\n".join(f"{k}={v}" for k, v in sorted(data.items()))
+    data["hash"] = hmac.new(secret, data_check.encode(), hashlib.sha256).hexdigest()
+    return data
+
+
+def _coach_headers():
+    res = client.post("/api/v1/auth/telegram", json={**_telegram_payload(1), "role": "coach"})
+    token = res.json()["access_token"]
+    return {"Authorization": f"Bearer {token}"}
+
+
+def test_invite_flow():
+    headers = _coach_headers()
+    res = client.post("/api/v1/invites/", json={}, headers=headers)
+    assert res.status_code == 200
+    token = res.json()["invite_token"]
+
+    payload = {
+        "telegram_id": 50,
+        "first_name": "Invited",
+        "bot_token": BOT_TOKEN,
+        "invite_token": token,
+    }
+    res2 = client.post("/api/v1/invites/bot", json=payload)
+    assert res2.status_code == 200
+
+    # reuse should fail
+    res3 = client.post("/api/v1/invites/bot", json=payload)
+    assert res3.status_code == 400


### PR DESCRIPTION
## Summary
- implement new Invite model
- issue invites and sign up via invite tokens
- expose new invite API endpoints
- test invitation flow

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686fbaeb3e4c8329990d3c6b9653de69