### PR TITLE
Add workout reminders and user time zones

### DIFF
--- a/trainer_bot/app/api/auth.py
+++ b/trainer_bot/app/api/auth.py
@@ -73,10 +73,13 @@ async def telegram_auth(auth: TelegramAuth):
                 last_name=auth.last_name,
                 username=auth.username,
                 role=(auth.role.value if auth.role else Role.athlete.value),
+                timezone=auth.timezone or os.getenv("TZ", "Europe/Moscow"),
             )
             session.add(user)
             session.commit()
             session.refresh(user)
+        elif auth.timezone:
+            user.timezone = auth.timezone
         access = create_access_token(user.id)
         refresh = create_refresh_token(user.id)
         user.refresh_token = refresh
@@ -98,10 +101,13 @@ async def bot_auth(data: BotAuth):
                 last_name=data.last_name,
                 username=data.username,
                 role=(data.role.value if data.role else Role.athlete.value),
+                timezone=data.timezone or os.getenv("TZ", "Europe/Moscow"),
             )
             session.add(user)
             session.commit()
             session.refresh(user)
+        elif data.timezone:
+            user.timezone = data.timezone
         access = create_access_token(user.id)
         refresh = create_refresh_token(user.id)
         user.refresh_token = refresh

--- a/trainer_bot/app/api/workouts.py
+++ b/trainer_bot/app/api/workouts.py
@@ -3,6 +3,7 @@ from typing import List
 
 from ..schemas.workout import WorkoutCreate, Workout as WorkoutSchema
 from ..services.db import get_session
+from ..services.scheduler import schedule_workout_reminder
 from ..models import Workout, Set
 from ..schemas.set import SetCreate
 from .auth import get_current_user, require_roles, Role
@@ -21,7 +22,8 @@ async def create_workout(workout: WorkoutCreate, user=Depends(require_roles([Rol
         session.add(obj)
         session.commit()
         session.refresh(obj)
-        return obj
+    schedule_workout_reminder(obj)
+    return obj
 
 @router.get("/{workout_id}", response_model=WorkoutSchema)
 async def get_workout(workout_id: int, user=Depends(get_current_user)):
@@ -41,7 +43,8 @@ async def update_workout(workout_id: int, workout: WorkoutCreate, user=Depends(r
             setattr(obj, key, value)
         session.commit()
         session.refresh(obj)
-        return obj
+    schedule_workout_reminder(obj)
+    return obj
 
 @router.delete("/{workout_id}")
 async def delete_workout(workout_id: int, user=Depends(require_roles([Role.coach, Role.superadmin]))):

--- a/trainer_bot/app/models.py
+++ b/trainer_bot/app/models.py
@@ -91,6 +91,7 @@ class User(Base):
     username = Column(String)
     role = Column(String, default=Role.athlete.value, nullable=False)
     refresh_token = Column(String, nullable=True)
+    timezone = Column(String, default="Europe/Moscow")
 
 
 class Invite(Base):

--- a/trainer_bot/app/schemas/auth.py
+++ b/trainer_bot/app/schemas/auth.py
@@ -10,6 +10,7 @@ class TelegramAuth(BaseModel):
     hash: str
     role: Role | None = None
     invite_token: str | None = None
+    timezone: str | None = None
 
 class TokenPair(BaseModel):
     access_token: str
@@ -28,6 +29,7 @@ class BotAuth(BaseModel):
     bot_token: str
     role: Role | None = None
     invite_token: str | None = None
+    timezone: str | None = None
 
 class RoleUpdate(BaseModel):
     role: Role

--- a/trainer_bot/app/schemas/user.py
+++ b/trainer_bot/app/schemas/user.py
@@ -3,6 +3,7 @@ from pydantic import BaseModel
 class User(BaseModel):
     id: int
     role: str
+    timezone: str | None = None
 
     class Config:
         from_attributes = True

--- a/trainer_bot/migrations/versions/0006_add_user_timezone.py
+++ b/trainer_bot/migrations/versions/0006_add_user_timezone.py
@@ -1,0 +1,15 @@
+from alembic import op
+import sqlalchemy as sa
+
+revision = '0006_add_user_timezone'
+down_revision = '0005_add_exercises'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('users', sa.Column('timezone', sa.String(), nullable=True))
+
+
+def downgrade():
+    op.drop_column('users', 'timezone')


### PR DESCRIPTION
## Summary
- support per-user `timezone`
- schedule workout reminders on creation and on startup
- daily reminder checks incomplete data at 20:00
- late report reminder at 23:59
- migrations for new timezone column

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686fbca3a9188329aa7153418f6c6e9a