### PR TITLE
Add coverage tests

### DIFF
--- a/trainer_bot/tests/integration/test_access.py
+++ b/trainer_bot/tests/integration/test_access.py
@@ -1,0 +1,50 @@
+import os
+os.environ["BOT_TOKEN"] = "123456:TESTTOKEN"
+
+import hashlib
+import hmac
+import jwt
+from trainer_bot.app.main import app
+from fastapi.testclient import TestClient
+
+client = TestClient(app)
+BOT_TOKEN = "123456:TESTTOKEN"
+
+
+def _telegram_payload(user_id: int = 1, role: str | None = None):
+    data = {
+        "id": user_id,
+        "first_name": "Test",
+        "auth_date": 1,
+    }
+    secret = hashlib.sha256(BOT_TOKEN.encode()).digest()
+    data_check = "\n".join(f"{k}={v}" for k, v in sorted(data.items()))
+    data["hash"] = hmac.new(secret, data_check.encode(), hashlib.sha256).hexdigest()
+    if role:
+        data["role"] = role
+    return data
+
+
+def _auth_headers(role="athlete", user_id: int = 5):
+    res = client.post("/api/v1/auth/telegram", json=_telegram_payload(user_id=user_id, role=role))
+    token = res.json()["access_token"]
+    return {"Authorization": f"Bearer {token}"}
+
+
+def test_athlete_cannot_issue_invite():
+    headers = _auth_headers(role="athlete")
+    res = client.post("/api/v1/invites/", json={}, headers=headers)
+    assert res.status_code == 403
+
+
+def test_non_admin_cannot_change_role():
+    headers = _auth_headers(role="coach", user_id=10)
+    res = client.post("/api/v1/auth/telegram", json=_telegram_payload(user_id=20, role="athlete"))
+    token = res.json()["access_token"]
+    target_uid = int(jwt.decode(token, "secret", algorithms=["HS256"])["sub"])
+    res = client.patch(
+        f"/api/v1/auth/users/{target_uid}/role", json={"role": "coach"}, headers=headers
+    )
+    assert res.status_code == 403
+
+

--- a/trainer_bot/tests/integration/test_exercises.py
+++ b/trainer_bot/tests/integration/test_exercises.py
@@ -33,3 +33,21 @@ def test_create_exercise():
     data = res.json()
     assert data["name"] == "Squat"
     assert data["metric_type"] == "strength"
+
+
+def test_exercise_crud():
+    headers = _auth_headers()
+    res = client.post("/api/v1/exercises/", json={"name": "Row", "metric_type": "strength"}, headers=headers)
+    ex_id = res.json()["id"]
+
+    res = client.get("/api/v1/exercises/", headers=headers)
+    assert any(e["id"] == ex_id for e in res.json())
+
+    res = client.get(f"/api/v1/exercises/{ex_id}", headers=headers)
+    assert res.status_code == 200
+
+    res = client.patch(f"/api/v1/exercises/{ex_id}", json={"name": "Row2", "metric_type": "strength"}, headers=headers)
+    assert res.json()["name"] == "Row2"
+
+    res = client.delete(f"/api/v1/exercises/{ex_id}", headers=headers)
+    assert res.json()["status"] == "deleted"

--- a/trainer_bot/tests/integration/test_messages.py
+++ b/trainer_bot/tests/integration/test_messages.py
@@ -1,0 +1,38 @@
+import os
+os.environ["BOT_TOKEN"] = "123456:TESTTOKEN"
+
+import hashlib
+import hmac
+from trainer_bot.app.main import app
+from fastapi.testclient import TestClient
+
+client = TestClient(app)
+BOT_TOKEN = "123456:TESTTOKEN"
+
+
+def _telegram_payload(user_id: int = 1, role: str | None = None):
+    data = {"id": user_id, "first_name": "Test", "auth_date": 1}
+    secret = hashlib.sha256(BOT_TOKEN.encode()).digest()
+    data_check = "\n".join(f"{k}={v}" for k, v in sorted(data.items()))
+    data["hash"] = hmac.new(secret, data_check.encode(), hashlib.sha256).hexdigest()
+    if role:
+        data["role"] = role
+    return data
+
+
+def _auth_headers():
+    res = client.post("/api/v1/auth/telegram", json=_telegram_payload(role="coach"))
+    token = res.json()["access_token"]
+    return {"Authorization": f"Bearer {token}"}
+
+
+def test_create_and_list_messages():
+    headers = _auth_headers()
+    msg = {"sender_id": 1, "receiver_id": 2, "text": "Hi"}
+    res = client.post("/api/v1/messages/", json=msg, headers=headers)
+    assert res.status_code == 200
+    msg_id = res.json()["id"]
+
+    res = client.get("/api/v1/messages/", headers=headers)
+    assert any(m["id"] == msg_id for m in res.json())
+

--- a/trainer_bot/tests/integration/test_plans.py
+++ b/trainer_bot/tests/integration/test_plans.py
@@ -36,3 +36,21 @@ def test_create_plan():
     data = res.json()
     assert data["title"] == "Plan A"
     assert "id" in data
+
+
+def test_plan_crud():
+    headers = _auth_headers()
+    res = client.post("/api/v1/plans/", json={"title": "Plan B"}, headers=headers)
+    plan_id = res.json()["id"]
+
+    res = client.get("/api/v1/plans/", headers=headers)
+    assert any(p["id"] == plan_id for p in res.json())
+
+    res = client.get(f"/api/v1/plans/{plan_id}", headers=headers)
+    assert res.status_code == 200
+
+    res = client.patch(f"/api/v1/plans/{plan_id}", json={"title": "Plan C"}, headers=headers)
+    assert res.json()["title"] == "Plan C"
+
+    res = client.delete(f"/api/v1/plans/{plan_id}", headers=headers)
+    assert res.json()["status"] == "deleted"

--- a/trainer_bot/tests/integration/test_workouts_time.py
+++ b/trainer_bot/tests/integration/test_workouts_time.py
@@ -37,3 +37,46 @@ def test_create_workout_with_time():
     assert res.status_code == 200
     data = res.json()
     assert data["time"] == "10:30:00"
+
+
+def test_schedule_called_on_create(monkeypatch):
+    headers = _auth_headers()
+    payload = {"athlete_id": 1, "date": "2025-01-05", "time": "09:00", "type": "strength", "title": "S"}
+    called = {}
+
+    def fake_schedule(w):
+        called["id"] = w.id
+
+    monkeypatch.setattr("trainer_bot.app.api.workouts.schedule_workout_reminder", fake_schedule)
+    res = client.post("/api/v1/workouts/", json=payload, headers=headers)
+    assert res.status_code == 200
+    assert "id" in called
+
+
+def test_schedule_called_on_update(monkeypatch):
+    headers = _auth_headers()
+    payload = {"athlete_id": 1, "date": "2025-01-06", "time": "08:00", "type": "strength", "title": "U"}
+    res = client.post("/api/v1/workouts/", json=payload, headers=headers)
+    wid = res.json()["id"]
+    called = {}
+
+    def fake_schedule(w):
+        called["id"] = w.id
+
+    monkeypatch.setattr("trainer_bot.app.api.workouts.schedule_workout_reminder", fake_schedule)
+    res = client.patch(f"/api/v1/workouts/{wid}", json=payload, headers=headers)
+    assert res.status_code == 200
+    assert called["id"] == wid
+
+
+def test_get_and_delete_workout():
+    headers = _auth_headers()
+    payload = {"athlete_id": 1, "date": "2025-01-07", "type": "strength", "title": "D"}
+    res = client.post("/api/v1/workouts/", json=payload, headers=headers)
+    wid = res.json()["id"]
+
+    res = client.get(f"/api/v1/workouts/{wid}", headers=headers)
+    assert res.status_code == 200
+
+    res = client.delete(f"/api/v1/workouts/{wid}", headers=headers)
+    assert res.json()["status"] == "deleted"

--- a/trainer_bot/tests/unit/test_models.py
+++ b/trainer_bot/tests/unit/test_models.py
@@ -1,0 +1,55 @@
+import datetime
+from trainer_bot.app.models import Role, Invite, User, Workout, Athlete
+import uuid
+from trainer_bot.app.services.db import get_session
+
+
+def test_role_enum_values():
+    assert [r.value for r in Role] == ["coach", "athlete", "superadmin"]
+
+
+def test_invite_defaults():
+    with get_session() as session:
+        user = session.query(User).filter(User.telegram_id == 9999).first()
+        if not user:
+            user = User(telegram_id=9999, first_name="Coach", role=Role.coach.value)
+            session.add(user)
+            session.commit()
+            session.refresh(user)
+        invite = Invite(jti=str(uuid.uuid4()), issued_by=user.id)
+        session.add(invite)
+        session.commit()
+        session.refresh(invite)
+        assert invite.used is False
+        assert invite.role == Role.athlete.value
+
+
+def test_user_default_timezone():
+    with get_session() as session:
+        user = session.query(User).filter(User.telegram_id == 9998).first()
+        if not user:
+            user = User(telegram_id=9998, first_name="U")
+            session.add(user)
+            session.commit()
+            session.refresh(user)
+        assert user.timezone == "Europe/Moscow"
+
+
+def test_workout_time_optional():
+    with get_session() as session:
+        athlete = Athlete(name="A")
+        session.add(athlete)
+        session.commit()
+        session.refresh(athlete)
+        w = Workout(
+            athlete_id=athlete.id,
+            date=datetime.date(2025, 1, 1),
+            type="strength",
+            title="W",
+        )
+        session.add(w)
+        session.commit()
+        session.refresh(w)
+        assert w.time is None
+
+

--- a/trainer_bot/tests/unit/test_parser.py
+++ b/trainer_bot/tests/unit/test_parser.py
@@ -26,3 +26,22 @@ def test_parse_cardio_cell():
     assert data["distance_km"] == 5.0
     assert data["duration_sec"] == 1530
     assert data["avg_hr"] == 150
+
+
+def test_parse_strength_cell_with_spaces():
+    sets = parse_strength_cell(" 75 kg ×5 ×2 ")
+    assert len(sets) == 2
+    assert sets[0]["weight"] == 75.0
+
+
+def test_parse_cardio_cell_distance_only():
+    data = parse_cardio_cell("3 km")
+    assert data["distance_km"] == 3.0
+    assert data["duration_sec"] is None
+    assert data["avg_hr"] is None
+
+
+def test_parse_cardio_cell_invalid():
+    import pytest
+    with pytest.raises(ValueError):
+        parse_cardio_cell("bad data")


### PR DESCRIPTION
## Summary
- cover parser edge cases
- exercise CRUD tests
- plan CRUD tests
- invite telegram signup scenario
- role-based access checks
- workout reminder scheduling
- models defaults
- add messages API tests

## Testing
- `ruff check .`
- `pytest --cov=trainer_bot --cov-report=term --cov-fail-under=70`

------
https://chatgpt.com/codex/tasks/task_e_686fbeba4a7c8329af0efdcae0dafac1