### PR TITLE
Implement invite handling in bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,19 @@ token is issued a new user with the `athlete` role is created in the database.
 The available roles are `coach`, `athlete` and `superadmin`. Any endpoint that
 requires a different role will return `403` until the user's role is updated.
 
+### Inviting users
+
+Coaches can generate invitation links for new athletes with:
+
+```text
+/invite [role]
+```
+
+The bot responds with an `invite_token` and a deep link like
+`https://t.me/<botname>?start=<token>`. A new user can follow this link or send
+`/signup <token>` to register. The bot submits the token to `/api/v1/invites/bot`
+and stores the received `access_token` for future requests.
+
 ### Using API commands via Telegram
 
 The bot exposes an `/api` command so the trainer can call any backend endpoint


### PR DESCRIPTION
## Summary
- allow coaches to issue invites via `/invite [role]`
- add invite-based sign-up support and command `/signup`
- store tokens received from invites for future API calls
- document invite flow in README

## Testing
- `ruff check .`
- `pytest -q` *(fails: test_change_user_role, test_protected_ping)*

------
https://chatgpt.com/codex/tasks/task_e_6870a8e12a7483299a580596cb32f580