### PR TITLE
Install postgres for CI tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,8 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: '3.12'
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y postgresql
       - run: pip install -r requirements.txt
       - name: Lint
         run: ruff .

--- a/README.md
+++ b/README.md
@@ -104,6 +104,13 @@ zone. If unset, the application defaults to **Europe/Moscow**.
 
 ### Running tests
 
+Install the development requirements first so that packages such as
+`testing.postgresql` are available:
+
+```bash
+pip install -r requirements.txt
+```
+
 The test suite expects a Telegram bot token via the `BOT_TOKEN` environment
 variable. Any value will work for local testing:
 


### PR DESCRIPTION
## Summary
- install postgresql in CI so `testing.postgresql` works
- document how to install test requirements locally

## Testing
- `pytest -q` *(fails: 1 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_6870c18035208329bdbb8cc9cdc2ed1a