### PR TITLE
Improve help command based on user role

### DIFF
--- a/trainer_bot/app/bots/telegram/dispatcher.py
+++ b/trainer_bot/app/bots/telegram/dispatcher.py
@@ -125,13 +125,43 @@ async def menu_cmd(message: Message):
 
 @dp.message(Command("help"))
 async def help_cmd(message: Message):
-    await message.answer(
-        "Доступные команды: /start /menu /help /today /future /invite /signup "
-        "/add_athlete /add_workout /add_set /plans /add_plan /get_contra /set_contra /pending "
-        "/messages /notifications /ex_list /ex_add /ex_get /ex_update /ex_delete "
-        "/workouts /workout_get /workout_update /workout_delete "
-        "/plan_get /plan_update /plan_delete /report_daily"
-    )
+    role = await _get_role(message.from_user)
+    commands = [
+        "/start",
+        "/menu",
+        "/help",
+        "/today",
+        "/future",
+        "/messages",
+        "/notifications",
+        "/signup",
+        "/report_daily",
+        "/workouts",
+        "/workout_get",
+        "/plan_get",
+        "/ex_list",
+        "/ex_get",
+    ]
+    if role in ["coach", "superadmin"]:
+        commands.extend([
+            "/add_athlete",
+            "/add_workout",
+            "/add_set",
+            "/plans",
+            "/add_plan",
+            "/set_contra",
+            "/get_contra",
+            "/invite",
+            "/pending",
+            "/ex_add",
+            "/ex_update",
+            "/ex_delete",
+            "/workout_update",
+            "/workout_delete",
+            "/plan_update",
+            "/plan_delete",
+        ])
+    await message.answer("Доступные команды: " + " ".join(commands))
 
 @dp.message(Command("today"))
 async def today_cmd(message: Message):

--- a/trainer_bot/tests/unit/test_dispatcher_help.py
+++ b/trainer_bot/tests/unit/test_dispatcher_help.py
@@ -1,0 +1,53 @@
+import asyncio
+from trainer_bot.app.bots.telegram import dispatcher
+
+class DummyUser:
+    id = 1
+    first_name = "T"
+
+class DummyChat:
+    id = 1
+
+class DummyMessage:
+    def __init__(self):
+        self.from_user = DummyUser()
+        self.chat = DummyChat()
+        self.answers = []
+    async def answer(self, text):
+        self.answers.append(text)
+
+
+def run(coro):
+    return asyncio.run(coro)
+
+
+def test_help_cmd_athlete(monkeypatch):
+    async def fake_role(user):
+        return "athlete"
+    monkeypatch.setattr(dispatcher, "_get_role", fake_role)
+    msg = DummyMessage()
+    run(dispatcher.help_cmd(msg))
+    expected = "Доступные команды: " + " ".join([
+        "/start", "/menu", "/help", "/today", "/future",
+        "/messages", "/notifications", "/signup", "/report_daily",
+        "/workouts", "/workout_get", "/plan_get", "/ex_list", "/ex_get",
+    ])
+    assert msg.answers == [expected]
+
+
+def test_help_cmd_coach(monkeypatch):
+    async def fake_role(user):
+        return "coach"
+    monkeypatch.setattr(dispatcher, "_get_role", fake_role)
+    msg = DummyMessage()
+    run(dispatcher.help_cmd(msg))
+    expected = "Доступные команды: " + " ".join([
+        "/start", "/menu", "/help", "/today", "/future",
+        "/messages", "/notifications", "/signup", "/report_daily",
+        "/workouts", "/workout_get", "/plan_get", "/ex_list", "/ex_get",
+        "/add_athlete", "/add_workout", "/add_set", "/plans", "/add_plan",
+        "/set_contra", "/get_contra", "/invite", "/pending", "/ex_add",
+        "/ex_update", "/ex_delete", "/workout_update", "/workout_delete",
+        "/plan_update", "/plan_delete",
+    ])
+    assert msg.answers == [expected]


### PR DESCRIPTION
## Summary
- adjust telegram bot's `/help` to list commands by user role
- add unit tests for `/help` command

## Testing
- `ruff check trainer_bot`
- `pytest -q` *(fails: 1 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_6870e81bfc4083298a2706f127356bda