### PR TITLE
Enable admin menu

### DIFF
--- a/trainer_bot/app/bots/telegram/dispatcher.py
+++ b/trainer_bot/app/bots/telegram/dispatcher.py
@@ -97,7 +97,7 @@ async def show_menu(chat_id: int, tg_user=None):
         [InlineKeyboardButton(text="Тренировки на сегодня", callback_data="cmd:today")],
         [InlineKeyboardButton(text="Предстоящие тренировки", callback_data="cmd:future")],
     ]
-    if role == "coach":
+    if role in ["coach", "superadmin"]:
         keyboard.extend([
             [InlineKeyboardButton(text="Добавить атлета", callback_data="cmd:add_athlete")],
             [InlineKeyboardButton(text="Добавить тренировку", callback_data="cmd:add_workout")],

--- a/trainer_bot/tests/unit/test_dispatcher_help.py
+++ b/trainer_bot/tests/unit/test_dispatcher_help.py
@@ -51,3 +51,25 @@ def test_help_cmd_coach(monkeypatch):
         "/plan_update", "/plan_delete",
     ])
     assert msg.answers == [expected]
+
+
+def test_show_menu_superadmin(monkeypatch):
+    async def fake_role(user):
+        return "superadmin"
+    monkeypatch.setattr(dispatcher, "_get_role", fake_role)
+
+    captured = {}
+
+    async def fake_send_message(chat_id, text, reply_markup=None):
+        captured["chat_id"] = chat_id
+        captured["text"] = text
+        captured["markup"] = reply_markup
+
+    monkeypatch.setattr(dispatcher.bot, "send_message", fake_send_message)
+
+    run(dispatcher.show_menu(1, DummyUser()))
+
+    buttons = [btn.text for row in captured["markup"].inline_keyboard for btn in row]
+
+    assert "Добавить атлета" in buttons
+    assert "Инвайт" in buttons


### PR DESCRIPTION
## Summary
- include superadmin role in the menu check so they see coach options
- test that superadmin users receive extended menu

## Testing
- `pytest -q` *(fails: 1 skipped because PostgreSQL executable `initdb` is missing)*

------
https://chatgpt.com/codex/tasks/task_e_6870ef9cee10832990fb49873de8226e