### PR TITLE
Add interactive exercise creation flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,12 @@ identifier), the workout date in `YYYY-MM-DD` format, a type such as
 `strength` or `cardio`, and a short title. After the object is created the
 bot returns to the main menu.
 
+Exercises can also be managed interactively. Choose **Новое упражнение** in
+the *Упражнения* menu or send `/ex_add` without arguments. The bot will ask for
+the exercise name followed by its metric type (`strength` or `cardio`).
+To update an existing exercise send `/ex_update <id>` and follow the prompts to
+change its name and metric type.
+
 ### Authorizing via Telegram
 
 At the first interaction the bot requests an API token from the backend by


### PR DESCRIPTION
## Summary
- make `/ex_add` start a step-by-step creation flow
- allow `/ex_update <id>` to start interactive update
- add states for exercise creation and update in the Telegram dispatcher
- expose **Новое упражнение** button in the exercise menu
- document the workflow in the README

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6871053bce8c83299e0d77eb0f06c010