### PR TITLE
Fix Telegram ID overflow

### DIFF
--- a/trainer_bot/app/models.py
+++ b/trainer_bot/app/models.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, Integer, String, Date, Time, Text, Float, ForeignKey, DateTime, Boolean
+from sqlalchemy import Column, Integer, BigInteger, String, Date, Time, Text, Float, ForeignKey, DateTime, Boolean
 from sqlalchemy.orm import relationship
 import datetime
 
@@ -87,7 +87,7 @@ class Notification(Base):
 class User(Base):
     __tablename__ = 'users'
     id = Column(Integer, primary_key=True)
-    telegram_id = Column(Integer, unique=True, nullable=False)
+    telegram_id = Column(BigInteger, unique=True, nullable=False)
     first_name = Column(String)
     last_name = Column(String)
     username = Column(String)

--- a/trainer_bot/migrations/versions/0009_change_telegram_id_type.py
+++ b/trainer_bot/migrations/versions/0009_change_telegram_id_type.py
@@ -1,0 +1,15 @@
+from alembic import op
+import sqlalchemy as sa
+
+revision = '0009_change_telegram_id_type'
+down_revision = '0008_add_set_rest_sec'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.alter_column('users', 'telegram_id', type_=sa.BigInteger())
+
+
+def downgrade():
+    op.alter_column('users', 'telegram_id', type_=sa.Integer())


### PR DESCRIPTION
## Summary
- store Telegram user IDs as `BigInteger`
- add migration to update the column type

## Testing
- `ruff check .`
- `pytest` *(fails: 1 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_6871fab026688329a97923da7e0d159e