### PR TITLE
Configure Alembic migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,19 @@ docker exec -it test-db-1 psql -U trainer -d trainer -c "CREATE EXTENSION IF NOT
 
 Open <http://localhost:8000/docs> for the Swagger UI once the service is running.
 
+### Database migrations
+
+The project uses **Alembic** for schema migrations. After setting the
+`DATABASE_URL` environment variable you can upgrade the database to the latest
+version with:
+
+```bash
+alembic upgrade head
+```
+
+Run this command from the repository root so `alembic.ini` is found
+automatically.
+
 ### Running the Telegram bot
 
 The repository includes a minimal Telegram bot that responds to `/start`.

--- a/alembic.ini
+++ b/alembic.ini
@@ -1,0 +1,36 @@
+[alembic]
+script_location = trainer_bot/migrations
+sqlalchemy.url = env:DATABASE_URL
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+
+[logger_sqlalchemy]
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+propagate = 0
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ pytz
 APScheduler
 testing.postgresql
 psycopg2-binary
+alembic


### PR DESCRIPTION
## Summary
- add `alembic` to dependencies
- provide an `alembic.ini` pointing at `trainer_bot/migrations`
- document how to run migrations in README

## Testing
- `alembic current`
- `su postgres -c "psql -d trainer -c 'SELECT * FROM alembic_version;'"`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68720efbae7c83299a4a7908795ffa04