### PR TITLE
Clarify auto-registration behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,12 @@ token is issued a new user with the `athlete` role is created in the database.
 The available roles are `coach`, `athlete` and `superadmin`. Any endpoint that
 requires a different role will return `403` until the user's role is updated.
 
+When a command that requires authentication is issued before `/start` or
+`/signup`, the bot still calls `/api/v1/auth/bot`. If the `telegram_id` is not
+known the backend automatically registers a new athlete and returns an access
+token. To keep registration explicit you can change the bot so `get_auth_headers`
+is invoked only after a `/start` or `/signup` command.
+
 ### Inviting users
 
 Coaches can generate invitation links for new athletes with:

--- a/trainer_bot/app/bots/telegram/dispatcher.py
+++ b/trainer_bot/app/bots/telegram/dispatcher.py
@@ -22,6 +22,14 @@ user_tokens: Dict[int, str] = {}
 
 
 async def get_auth_headers(tg_user) -> Dict[str, str]:
+    """Return API auth headers for a Telegram user.
+
+    The first call for a given ``tg_user`` sends their profile to
+    ``/api/v1/auth/bot``. The backend creates a user if the ``telegram_id``
+    is unknown and returns an access token. Consequently any command that
+    needs authentication will automatically register the user when issued
+    without running ``/start`` or ``/signup`` first.
+    """
     token = os.getenv("TRAINER_API_TOKEN")
     if token:
         return {"Authorization": f"Bearer {token}"}


### PR DESCRIPTION
## Summary
- add a note about automatic user creation to the README
- document auto-registration in the `get_auth_headers` function

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: OperationalError - no such table)*

------
https://chatgpt.com/codex/tasks/task_e_6874c7ecc4048329af3ae0f66ce69aed