### PR TITLE
Clarify invite defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,12 +110,22 @@ is invoked only after a `/start` or `/signup` command.
 
 ### Inviting users
 
-Coaches can generate invitation links for new athletes with:
+Coaches can generate invitation links for new users:
 
 ```text
 /invite [role]
 ```
 
+The optional `role` argument may be `athlete` or `coach`. If you omit it, the
+command defaults to an athlete invite, so simply sending `/invite` is equivalent
+to `/invite athlete`. For example, to invite a new coach use:
+
+```text
+/invite coach
+```
+
+When no role is provided in Telegram, the bot shows an interactive menu so you
+can pick the desired role.
 
 The bot responds with an `invite_token` and a deep link like
 `https://t.me/<botname>?start=<token>`. A new user can follow this link or send


### PR DESCRIPTION
## Summary
- document that `/invite` defaults to an athlete role
- mention interactive role selection in README

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: sqlite3.OperationalError no such table: users)*

------
https://chatgpt.com/codex/tasks/task_e_6874cd8235a883298152c3ab8d1b0718